### PR TITLE
use 'kvm-bindings' from 'firecracker-microvm'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [0.5.0-1]
+
+Built on top of upstream rust-vmm/kvm-ioctls v0.5.0.
+
+## Changed
+
+- Consume 'kvm-bindings' dependency from 'github.com/firecracker-microvm'
+  which provides versioned bindings for x86_64 state structs.
+
 # v0.5.0
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = ">=0.2.39"
-kvm-bindings = { version = ">=0.2.0", features = ["fam-wrappers"] }
+kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-1", features = ["fam-wrappers"] }
 vmm-sys-util = ">=0.2.1"
 
 [dev-dependencies]

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 76.2,
+  "coverage_score": 76.7,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
*Issue #, if available:*

Part of https://github.com/firecracker-microvm/firecracker/issues/1831

*Description of changes:*

Consume 'kvm-bindings' dependency from 'github.com/firecracker-microvm' which provides versioned bindings for x86_64 state structs.

Release internal version `v0.5.0-1`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
