### PR TITLE
use kvm-bindings v0.2.0-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [0.5.0-2]
+
+## Changed
+
+- Upgrade to kvm-bindings v0.2.0-2 which uses versionize v0.1.1.
+
 # [0.5.0-1]
 
 Built on top of upstream rust-vmm/kvm-ioctls v0.5.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = ">=0.2.39"
-kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-1", features = ["fam-wrappers"] }
+kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }
 vmm-sys-util = ">=0.2.1"
 
 [dev-dependencies]

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 76.7,
+  "coverage_score": 77.0,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
*Description of changes:*

This PR upgrades kvm-bindings to v0.2.0-2. This is needed in order to upgrade to versionize 0.1.1 everywhere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
