### PR TITLE
Add support for KVM_SET_GUEST_DEBUG ioctl call.

### DIFF
--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1049,6 +1049,15 @@ impl VcpuFd {
         Ok(reg_value)
     }
 
+    /// Enables guest debugging and sets specific debug registers for x86
+    pub fn set_guest_debug(&self, debug_struct: &kvm_guest_debug) -> Result<()> {
+        let ret = unsafe { ioctl_with_ref(self, KVM_SET_GUEST_DEBUG(), debug_struct) };
+        if ret < 0 {
+            return Err(errno::Error::last());
+        }
+        Ok(())
+    }
+
     /// Triggers the running of the current virtual CPU returning an exit reason.
     ///
     /// See documentation for `KVM_RUN`.

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -225,6 +225,9 @@ ioctl_iow_nr!(KVM_GET_DEVICE_ATTR, KVMIO, 0xe2, kvm_device_attr);
 /* Available with KVM_CAP_DEVICE_CTRL */
 ioctl_iow_nr!(KVM_HAS_DEVICE_ATTR, KVMIO, 0xe3, kvm_device_attr);
 
+
+ioctl_iow_nr!(KVM_SET_GUEST_DEBUG, KVMIO, 0x9b, kvm_guest_debug);
+
 #[cfg(test)]
 mod tests {
     use std::fs::File;


### PR DESCRIPTION
This enables us to handle software breakpoints, perform
single-stepping and, possibly, implement hardware breakpoints

Signed-off-by: Marius-Cristian Baciu <baciumar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
