### PR TITLE
readme: Deprecate this custom fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-[![Build Status](https://badge.buildkite.com/9e0e6c88972a3248a0908506d6946624da84e4e18c0870c4d0.svg)](https://buildkite.com/rust-vmm/kvm-ioctls-ci)
-![crates.io](https://img.shields.io/crates/v/kvm-ioctls.svg)
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+# DEPRECATED
+
+This is no longer supported, please consider using upstream
+https://github.com/rust-vmm/kvm-ioctls directly.
 
 # kvm-ioctls
 


### PR DESCRIPTION
This fork was used by Firecracker to be able to consume custom versioned `kvm-bindings` through https://github.com/firecracker-microvm/kvm-bindings

Firecracker now uses cargo `[patch]` to directly patch the custom `kvm-bindings`, so this custom fork of `kvm-ioctls` is no longer needed.

It is now deprecated and not maintained anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
